### PR TITLE
fix: fix a bug that ghir fails if there are more than 100 releases

### DIFF
--- a/pkg/github/list_releases.go
+++ b/pkg/github/list_releases.go
@@ -80,7 +80,7 @@ func (c *Client) ListReleases(ctx context.Context, owner, repo string) ([]*Relea
 		if !pageInfo.HasNextPage {
 			return releases, nil
 		}
-		variables["cursor"] = pageInfo.EndCursor
+		variables["cursor"] = githubv4.String(pageInfo.EndCursor)
 	}
 	return releases, nil
 }


### PR DESCRIPTION
Close #13