### PR TITLE
feat: reduce GitHub API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ export GHIR_ENABLE_GHTKN=true
 
 1. List GitHub Releases and get their descriptions by GitHub API
 1. Exclude draft releases and immutable releases
-1. Edit release description temporarily by GitHub API to make all releases immutable
-   1. Add a newline to the release description
-   2. Revert the change immediately
+1. Update releases without parameters by GitHub API to make all releases immutable
 
 ## LICENSE
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,7 +18,7 @@ func New(input *Input) *Controller {
 
 type GitHub interface {
 	ListReleases(ctx context.Context, owner, repo string) ([]*github.Release, error)
-	EditRelease(ctx context.Context, owner, repo string, releaseID int64, body string) error
+	EditRelease(ctx context.Context, owner, repo string, releaseID int64) error
 }
 
 type Input struct {

--- a/pkg/controller/run.go
+++ b/pkg/controller/run.go
@@ -42,12 +42,9 @@ func (c *Controller) Run(ctx context.Context, logger *slog.Logger, input *InputR
 	}
 	logger.Info("found mutable releases", "count", len(rs))
 	for _, release := range rs {
-		logger.Info("editing release description to make the release immutable", "tag", release.TagName, "release_id", release.DatabaseID)
-		if err := c.input.GitHub.EditRelease(ctx, input.RepoOwner, input.RepoName, release.DatabaseID, release.Description+"\n"); err != nil {
-			return fmt.Errorf("append a newline to the description of release: %w", slogerr.With(err, "tag", release.TagName, "release_id", release.DatabaseID))
-		}
-		if err := c.input.GitHub.EditRelease(ctx, input.RepoOwner, input.RepoName, release.DatabaseID, release.Description); err != nil {
-			return fmt.Errorf("remove a newline from the description of release: %w", slogerr.With(err, "tag", release.TagName, "release_id", release.DatabaseID))
+		logger.Info("update the release to make it immutable", "tag", release.TagName, "release_id", release.DatabaseID)
+		if err := c.input.GitHub.EditRelease(ctx, input.RepoOwner, input.RepoName, release.DatabaseID); err != nil {
+			return fmt.Errorf("update the release: %w", slogerr.With(err, "tag", release.TagName, "release_id", release.DatabaseID))
 		}
 	}
 	return nil

--- a/pkg/github/edit_release.go
+++ b/pkg/github/edit_release.go
@@ -6,16 +6,10 @@ import (
 	"github.com/google/go-github/v75/github"
 )
 
-type InputEditRelease struct {
-	ID int64
-}
-
-func (c *Client) EditRelease(ctx context.Context, owner, repo string, id int64, description string) error {
+func (c *Client) EditRelease(ctx context.Context, owner, repo string, id int64) error {
 	// GraphQL API does not support updating a release.
 	// https://docs.github.com/en/graphql/reference/mutations
 	// https://pkg.go.dev/github.com/google/go-github/v75/github#RepositoriesService.EditRelease
-	_, _, err := c.repos.EditRelease(ctx, owner, repo, id, &github.RepositoryRelease{
-		Body: github.Ptr(description),
-	})
+	_, _, err := c.repos.EditRelease(ctx, owner, repo, id, &github.RepositoryRelease{})
 	return err //nolint:wrapcheck
 }

--- a/pkg/github/list_releases.go
+++ b/pkg/github/list_releases.go
@@ -20,7 +20,6 @@ query($owner: String!, $repo: String!) {
         isDraft
         immutable
         tagName
-        description
       }
     }
   }
@@ -54,11 +53,10 @@ type PageInfo struct {
 }
 
 type Release struct {
-	Description string `json:"description"`
-	Immutable   bool   `json:"immutable"`
-	IsDraft     bool   `json:"isDraft"`
-	TagName     string `json:"tagName"`
-	DatabaseID  int64  `json:"databaseId"`
+	Immutable  bool   `json:"immutable"`
+	IsDraft    bool   `json:"isDraft"`
+	TagName    string `json:"tagName"`
+	DatabaseID int64  `json:"databaseId"`
 }
 
 func (c *Client) ListReleases(ctx context.Context, owner, repo string) ([]*Release, error) {


### PR DESCRIPTION
Instead of getting the release description and updating it temporarily, merely calling the GitHub API without any parameters only once.

Even if the update release API is called without any parameters, the API call succeeds and the release becomes immutable.