### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,10 +6,12 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@b2ecf54e35aca9e9689e761f5bd6d1ad9542a8cf # v8.0.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
       - run: exit 1
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write

--- a/.github/workflows/workflow_call_integration_test.yaml
+++ b/.github/workflows/workflow_call_integration_test.yaml
@@ -1,9 +1,15 @@
 ---
 name: integration test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   integration-test:
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     timeout-minutes: 20
     runs-on: ${{ matrix.runs-on }}
     strategy:
@@ -17,6 +23,11 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - run: |
           go install -ldflags "-X main.version=v1.0.0 -X main.commit=$GITHUB_SHA -X main.date=$(date +"%Y-%m-%dT%H:%M:%SZ%:z" | tr -d '+')" ./cmd/ghir
       - run: ghir -v

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,17 +1,28 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   integration-test:
     uses: ./.github/workflows/workflow_call_integration_test.yaml
-    permissions: {}
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+    permissions:
+      id-token: write
+      contents: read
 
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
       golangci-lint-timeout: 120s
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the CI workflows to guard Go module/tool downloads.

## Changes

- `.github/workflows/release.yaml`
  - Bump `go-release-workflow` ref from `v8.0.0` to `v8.1.0`.
  - Add `secrets.TAKUMI_GUARD_BOT_ID` to the `release` job.

- `.github/workflows/workflow_call_test.yaml`
  - Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`).
  - Bump `go-test-full-workflow` ref from `v5.0.2` to `v6.0.0`.
  - Pass `secrets.TAKUMI_GUARD_BOT_ID` and add `id-token: write` to the `test` job.
  - Pass `secrets.TAKUMI_GUARD_BOT_ID` and add `id-token: write` / `contents: read` to the local `integration-test` call.

- `.github/workflows/workflow_call_integration_test.yaml`
  - Declare `on.workflow_call.secrets.TAKUMI_GUARD_BOT_ID` (`required: true`).
  - Add the `flatt-security/setup-takumi-guard-golang@v1` step immediately after `actions/setup-go` and before the `go install` step.
  - Add `id-token: write` / `contents: read` to the `integration-test` job (was `{}`).

- `.github/workflows/test.yaml`
  - Pass `secrets.TAKUMI_GUARD_BOT_ID` and add `id-token: write` to the `test` job that calls the local reusable workflow, completing the secret chain from the `pull_request` entrypoint.

## Note

This bumps `go-test-full-workflow` across a major version (`v5.0.2` -> `v6.0.0`). Please review CI for potential breaking changes.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)