### PR TITLE
docs: update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@fix-cosign-bundle
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@1cf29d7b17983b901021799b87a55d357cfff790 # v9.0.0
     with:
       go-version-file: go.mod
       aqua_version: v2.60.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
 permissions: {}
 jobs:
   release:
-    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
+    uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@fix-cosign-bundle
     with:
       go-version-file: go.mod
       aqua_version: v2.60.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ghir (GitHub Immutable Releases)
 
-[![DeepWiki](https://img.shields.io/badge/DeepWiki-suzuki--shunsuke%2Fghir-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/suzuki-shunsuke/ghir)
-
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/suzuki-shunsuke/ghir)
 [Install](INSTALL.md)
 
 ghir is a CLI making past GitHub Releases immutable.
@@ -37,22 +36,15 @@ ghir requires a GitHub Access Token.
 - Required Permissions: `contents:write`
 - Scopes (accessible repositories): A repository to be updated
 
-Environment Variables
+The priority of the access token is as follows:
 
-1. `GHIR_GITHUB_TOKEN`
-1. `GITHUB_TOKEN`
-
-Or you can also use [ghtkn integration](https://github.com/suzuki-shunsuke/ghtkn).
-
-```sh
-export GHIR_ENABLE_GHTKN=true
-```
-
-Or
-
-```sh
-export GHTKN_ENABLE=true
-```
+1. Environment Variables
+    1. `GHIR_GITHUB_TOKEN`
+    1. `GITHUB_TOKEN`
+1. [ghtkn integration](https://github.com/suzuki-shunsuke/ghtkn)
+    1. `export GHIR_ENABLE_GHTKN=true`
+    1. `export GHTKN_ENABLE=true`
+    1. If the configuration file of ghtkn exists, the integration is enabled
 
 ## How It Works
 
@@ -61,24 +53,32 @@ export GHTKN_ENABLE=true
 1. Update releases without any parameters by GitHub API to make all releases immutable
 
 ## ProTip: Run ghir for multiple repositories
+
 ghir alone can only be executed in a single repository.
 
 However, by combining other tools, you can run ghir against multiple repositories.
 
-### Example 1: use repository list file
+### Example 1: Use repository list file
+
 ```sh
 cat repos.txt
 username_or_orgname/foo
 username_or_orgname/bar
 
-cat repos.txt | xargs -n 1 ghir
+cat repos.txt |
+  xargs -n 1 ghir
 ```
 
-### Example 2: use [gh repo list](https://cli.github.com/manual/gh_repo_list)
+### Example 2: Use `gh repo list`
+
+[gh repo list](https://cli.github.com/manual/gh_repo_list)
+
 ```sh
-gh repo list <username_or_orgname> --source --no-archived --json nameWithOwner --template '{{range .}}{{.nameWithOwner}}{{"\n"}}{{end}}' --limit 100 | xargs -n 1 ghir
+gh repo list [<owner>] \
+  --source \
+  --no-archived \
+  --json nameWithOwner \
+  --template '{{range .}}{{.nameWithOwner}}{{"\n"}}{{end}}' \
+  --limit 100 |
+  xargs -n 1 ghir
 ```
-
-## LICENSE
-
-[MIT](LICENSE)


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/go-release-workflow/pull/249

## ⚠️ Breaking Changes

- `*.sig` and `*.pem` files aren't published anymore
- `*.bundle` is renamed to `*.sigstore.json`