### PR TITLE
fix: remove --enable-ghtkn from the help text

### DIFF
--- a/pkg/cli/runner.go
+++ b/pkg/cli/runner.go
@@ -24,7 +24,7 @@ https://github.com/suzuki-shunsuke/ghir
 USAGE:
    ghir --help [-h] # Show this help
    ghir --version [-v] # Show version
-   ghir [--log-level <debug|info|warn|error>] [--enable-ghtkn] <owner>/<repo>
+   ghir [--log-level <debug|info|warn|error>] <owner>/<repo>
 
 VERSION:
    %s
@@ -33,7 +33,7 @@ VERSION:
 func Run(ctx context.Context, logger *slog.Logger, logLevel *slog.LevelVar, ldFlags *stdutil.LDFlags) error {
 	// GITHUB_TOKEN, GHIR_GITHUB_TOKEN
 	// GHIR_LOG_LEVEL -log-level
-	// GHIR_ENABLE_GHTKN -enable-ghtkn
+	// GHIR_ENABLE_GHTKN
 	flag := &Flag{}
 	parseFlags(flag)
 

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -61,7 +61,7 @@ func newTokenSource(logger *slog.Logger, input *InputNew) (oauth2.TokenSource, e
 		return nil, fmt.Errorf("check if ghtkn is enabled: %w", err)
 	}
 	if !ghtknEnabled {
-		return nil, errors.New("either GHTKNEnabled or AccessToken must be set")
+		return nil, errors.New("no GitHub access token is available: set GHIR_GITHUB_TOKEN or GITHUB_TOKEN, or enable the ghtkn integration with GHIR_ENABLE_GHTKN=true")
 	}
 	client, err := ghtkn.New()
 	if err != nil {


### PR DESCRIPTION
## Why

`--enable-ghtkn` was removed in #317, but the usage line in `pkg/cli/runner.go` still advertises it:

```console
$ ghir --help
USAGE:
   ghir [--log-level <debug|info|warn|error>] [--enable-ghtkn] <owner>/<repo>

$ ghir --enable-ghtkn suzuki-shunsuke/ghir
unknown flag: --enable-ghtkn
```

The README already documents the environment variables only, so the help text was the last place claiming the flag exists. It's misleading in the one situation where someone reads it: the integration isn't picking up a token and they're looking for a switch to turn it on.

## What changed

Drop `[--enable-ghtkn]` from the usage line, and from the env-to-flag comment above `Run`.

While here, replace the error raised when no token can be obtained:

```
either GHTKNEnabled or AccessToken must be set
```

`GHTKNEnabled` was a field on `InputNew` that #317 removed too, so the message names something that no longer exists and gives the user nothing to act on. It now names what actually resolves a token:

```
no GitHub access token is available: set GHIR_GITHUB_TOKEN or GITHUB_TOKEN, or enable the ghtkn integration with GHIR_ENABLE_GHTKN=true
```

Happy to split that second change out if you'd rather keep this to the help text.

## Verification

`go build ./...` and `go test ./...` pass. `ghir --help` shows the corrected usage line, and the error path was exercised with the token variables unset and `GHTKN_ENABLE=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)